### PR TITLE
feat(tauri): txt:// URL scheme + compose deep link + ⌥⇧T hotkey

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-Detach from upstream openmessage
-Rename Go module to github.com/jamesdowzard/txt, strip upstream refs from docs, remove upstream git remote, detach GitHub fork relationship. Keep bundle ID + binary name for codesign/data continuity.
+URL scheme + Shortcuts App Intents
+Register textbridge://compose URL scheme. Add macOS App Intents so Shortcuts.app can send messages through txt. Sidecar Swift binary or Tauri plugin.
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - detach-upstream
+# Agent Progress - tauri-surface
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-04-19T07:34:13Z
+# Created: 2026-04-19T07:54:38Z
 
-feature=detach-upstream
-name=Detach from upstream openmessage
+feature=tauri-surface
+name=URL scheme + Shortcuts App Intents
 status=pending
 step=0
 step_name=Not started
-created=2026-04-19T07:34:13Z
+created=2026-04-19T07:54:38Z

--- a/desktop/scripts/smoke-url-scheme
+++ b/desktop/scripts/smoke-url-scheme
@@ -1,0 +1,63 @@
+#!/bin/bash
+# End-to-end smoke test for the txt:// URL scheme compose auto-send path.
+#
+# Usage:
+#   ./scripts/smoke-url-scheme <recipient> <body>
+#   ./scripts/smoke-url-scheme                         # uses demo defaults
+#
+# Requires the app to be running (either /Applications/txt.app or
+# /Applications/txt-dev.app). Fires `open txt://compose?to=...&body=...`
+# and polls /api/search for the body until it shows up as an outgoing
+# message. Exit 0 = message queued / sent; non-zero = backend not reachable
+# or message never landed.
+set -euo pipefail
+
+RECIPIENT="${1:-+61400000000}"
+STAMP="$(date +%s)"
+BODY="${2:-smoke test ${STAMP}}"
+BACKEND_ORIGIN="${TXT_BACKEND_ORIGIN:-http://127.0.0.1:7007}"
+TIMEOUT_SECS="${TXT_SMOKE_TIMEOUT:-15}"
+
+echo "==> txt URL scheme smoke test"
+echo "    recipient: $RECIPIENT"
+echo "    body:      $BODY"
+echo "    backend:   $BACKEND_ORIGIN"
+echo
+
+# 1. Confirm backend is up. If not, the app isn't running — can't test.
+if ! curl -sS --max-time 3 -o /dev/null -w "%{http_code}" "$BACKEND_ORIGIN/api/status" | grep -qE '^(200|204)$'; then
+    echo "    ERROR: backend at $BACKEND_ORIGIN is not responding." >&2
+    echo "    Launch the app first: ./scripts/dev --launch" >&2
+    exit 2
+fi
+echo "    backend reachable"
+
+# 2. Fire the URL via LaunchServices. This dispatches into the Tauri shell,
+#    which either auto-sends (if both to + body are set) or opens the overlay.
+ENCODED_TO=$(/usr/bin/python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$RECIPIENT")
+ENCODED_BODY=$(/usr/bin/python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$BODY")
+URL="txt://compose?to=${ENCODED_TO}&body=${ENCODED_BODY}"
+echo "    firing: open '$URL'"
+open "$URL"
+
+# 3. Poll /api/search for the body. Google Messages / iMessage sends land
+#    in the message store right after /api/send returns SUCCESS, so the
+#    body being searchable means the whole chain worked.
+echo
+echo "==> Polling /api/search for body (timeout ${TIMEOUT_SECS}s)..."
+DEADLINE=$(( $(date +%s) + TIMEOUT_SECS ))
+ENCODED_SEARCH=$(/usr/bin/python3 -c 'import sys, urllib.parse; print(urllib.parse.quote(sys.argv[1], safe=""))' "$BODY")
+while (( $(date +%s) < DEADLINE )); do
+    RESULT=$(curl -sS --max-time 2 "$BACKEND_ORIGIN/api/search?q=${ENCODED_SEARCH}" || true)
+    if echo "$RESULT" | grep -q -- "$BODY"; then
+        echo "    FOUND — message landed in store."
+        echo
+        echo "    (sample hit: $(echo "$RESULT" | head -c 200)...)"
+        exit 0
+    fi
+    sleep 1
+done
+
+echo "    TIMED OUT after ${TIMEOUT_SECS}s — message did not appear in /api/search." >&2
+echo "    Check the app console (Console.app → 'txt') for [deep-link] errors." >&2
+exit 1

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -2,14 +2,12 @@ mod notifications;
 mod sse;
 
 use std::sync::Mutex;
-use tauri::{Emitter, Manager, RunEvent};
+use tauri::{AppHandle, Emitter, Manager, RunEvent};
 use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_plugin_global_shortcut::{Code, GlobalShortcutExt, Modifiers, Shortcut, ShortcutState};
 use tauri_plugin_shell::process::{CommandChild, CommandEvent};
 use tauri_plugin_shell::ShellExt;
 
-#[cfg(not(debug_assertions))]
-use tauri::AppHandle;
 #[cfg(not(debug_assertions))]
 use tauri_plugin_updater::UpdaterExt;
 
@@ -53,12 +51,15 @@ pub fn run() {
     // on macOS it fires the NSAppDelegate URL event which the deep-link
     // plugin already handles. Forward any URL-shaped argv entry to the
     // running instance so the behaviour is consistent across platforms.
+    // Matches both `txt://` (primary) and `textbridge://` (legacy).
     #[cfg(feature = "single-instance")]
     let builder = builder.plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
-        if let Some(url) = args.iter().find(|a| a.starts_with("textbridge://")) {
-            let _ = app.emit(DEEP_LINK_EVENT, url.clone());
-        }
-        if let Some(main) = app.get_webview_window("main") {
+        if let Some(url) = args
+            .iter()
+            .find(|a| a.starts_with("txt://") || a.starts_with("textbridge://"))
+        {
+            dispatch_deep_link(app, url.clone());
+        } else if let Some(main) = app.get_webview_window("main") {
             let _ = main.set_focus();
         }
     }));
@@ -104,12 +105,14 @@ pub fn run() {
                 }
             });
 
-            // Forward textbridge://… URLs to the WebView. Fires on every
-            // macOS NSAppDelegate "open URLs" event (cold launch + hot).
+            // Forward txt://… / textbridge://… URLs to either the background
+            // auto-send path (compose with both `to` + `body`) or the WebView
+            // (everything else — opens overlay, focuses window). Fires on
+            // every macOS NSAppDelegate "open URLs" event (cold + hot).
             let deep_link_handle = app.handle().clone();
             app.deep_link().on_open_url(move |event| {
                 for url in event.urls() {
-                    let _ = deep_link_handle.emit(DEEP_LINK_EVENT, url.to_string());
+                    dispatch_deep_link(&deep_link_handle, url.to_string());
                 }
             });
 
@@ -203,6 +206,163 @@ fn open_conversation_window(
     .build()
     .map_err(|e| e.to_string())?;
 
+    Ok(())
+}
+
+/// Route a `txt://…` or `textbridge://…` URL to either the background
+/// auto-send path or the WebView. A `compose` URL with both `to` and `body`
+/// is treated as "send this now" and bypasses the WebView entirely — the app
+/// window is NOT brought to the front (Shortcuts-style background send).
+/// Everything else is emitted to the WebView, which opens the compose
+/// overlay and focuses the window.
+fn dispatch_deep_link(app: &AppHandle, raw: String) {
+    let parsed = match url::Url::parse(&raw) {
+        Ok(u) => u,
+        Err(err) => {
+            eprintln!("[deep-link] invalid URL {raw}: {err}");
+            return;
+        }
+    };
+
+    let action = parsed
+        .host_str()
+        .map(|s| s.to_ascii_lowercase())
+        .unwrap_or_default();
+
+    if action == "compose" {
+        let mut to = String::new();
+        let mut body = String::new();
+        for (k, v) in parsed.query_pairs() {
+            match k.as_ref() {
+                "to" => to = v.into_owned(),
+                "body" => body = v.into_owned(),
+                _ => {}
+            }
+        }
+        if !to.is_empty() && !body.is_empty() {
+            // Background send — don't steal focus. On failure, fall back
+            // to the WebView path so the user still gets the overlay with
+            // their inputs prefilled and can retry.
+            let fallback = app.clone();
+            let raw_for_fallback = raw.clone();
+            tauri::async_runtime::spawn(async move {
+                if let Err(err) = send_via_handle(&to, &body).await {
+                    eprintln!(
+                        "[deep-link] compose send failed ({err}); falling back to WebView overlay"
+                    );
+                    if let Some(main) = fallback.get_webview_window("main") {
+                        let _ = main.show();
+                        let _ = main.unminimize();
+                        let _ = main.set_focus();
+                    }
+                    let _ = fallback.emit(DEEP_LINK_EVENT, raw_for_fallback);
+                }
+            });
+            return;
+        }
+    }
+
+    // Default: focus the window and hand off to the WebView.
+    if let Some(main) = app.get_webview_window("main") {
+        let _ = main.show();
+        let _ = main.unminimize();
+        let _ = main.set_focus();
+    }
+    let _ = app.emit(DEEP_LINK_EVENT, raw);
+}
+
+/// Resolve a recipient handle to a conversation ID and POST the body to
+/// `/api/send`. For `@`-shaped handles we assume iMessage (`imessage:<handle>`);
+/// for everything else we call `/api/new-conversation` to get-or-create a
+/// Google Messages conversation. Errors bubble up to the caller (logged).
+async fn send_via_handle(to: &str, body: &str) -> Result<(), String> {
+    let handle = to.trim();
+    if handle.is_empty() {
+        return Err("empty recipient handle".to_string());
+    }
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(15))
+        .build()
+        .map_err(|e| format!("build http client: {e}"))?;
+
+    // Resolve handle → conversation_id.
+    let conversation_id = if handle.contains('@') {
+        // Email → iMessage. The Go backend keys iMessage conversations by
+        // `imessage:<handle>` directly.
+        format!("imessage:{handle}")
+    } else {
+        let digits_only = handle
+            .chars()
+            .filter(|c| c.is_ascii_digit() || *c == '+')
+            .collect::<String>();
+        let is_phone = !digits_only.is_empty()
+            && digits_only
+                .chars()
+                .filter(|c| c.is_ascii_digit())
+                .count()
+                >= 5;
+
+        if !is_phone {
+            return Err(format!("unrecognised handle shape: {handle}"));
+        }
+
+        // Phone → get-or-create a Google Messages conversation via the
+        // existing resolver. This is the same endpoint the New Message
+        // overlay in the WebView uses.
+        let url = format!("{}/api/new-conversation", BACKEND_ORIGIN);
+        let resp = client
+            .post(&url)
+            .json(&serde_json::json!({ "phone_number": handle }))
+            .send()
+            .await
+            .map_err(|e| format!("POST /api/new-conversation: {e}"))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(format!(
+                "/api/new-conversation returned {status}: {text}"
+            ));
+        }
+
+        let parsed: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| format!("parse /api/new-conversation response: {e}"))?;
+
+        parsed
+            .get("conversation_id")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| {
+                format!(
+                    "/api/new-conversation returned no conversation_id (got {parsed})"
+                )
+            })?
+    };
+
+    // POST the body to /api/send.
+    let url = format!("{}/api/send", BACKEND_ORIGIN);
+    let resp = client
+        .post(&url)
+        .json(&serde_json::json!({
+            "conversation_id": conversation_id,
+            "message": body,
+        }))
+        .send()
+        .await
+        .map_err(|e| format!("POST /api/send: {e}"))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let text = resp.text().await.unwrap_or_default();
+        return Err(format!("/api/send returned {status}: {text}"));
+    }
+
+    eprintln!(
+        "[deep-link] compose sent: conversation_id={conversation_id} (handle={handle})"
+    );
     Ok(())
 }
 

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -54,7 +54,7 @@
     },
     "deep-link": {
       "desktop": {
-        "schemes": ["textbridge"]
+        "schemes": ["txt", "textbridge"]
       }
     }
   }

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -1,52 +1,98 @@
-# Textbridge × macOS Shortcuts
+# txt × macOS Shortcuts
 
-Textbridge exposes its actions to macOS Shortcuts (and any other URL-capable
-automation tool) via the `textbridge://` URL scheme. There's no App Intents
-bundle — Shortcuts.app's built-in **Open URLs** action is wired to the
-scheme handler in `desktop/src-tauri/src/lib.rs`, so every Shortcut below is
-a one-action recipe.
+txt exposes its actions to macOS Shortcuts (and any other URL-capable
+automation tool) via the `txt://` URL scheme. `textbridge://` is still
+registered as a legacy alias so old shortcuts and recipes keep working —
+use `txt://` in anything new.
+
+There's no dedicated App Intents bundle. Shortcuts.app's built-in **Open
+URLs** action is wired to the scheme handler in
+`desktop/src-tauri/src/lib.rs`, so every Shortcut below is a one-action
+recipe. See [Design rationale](#design-rationale-url-scheme-vs-app-intents)
+at the bottom of this doc for why.
 
 ## Actions
 
 | URL | Effect |
 |-----|--------|
-| `textbridge://compose?to=+61412345678&body=optional+text` | Opens Textbridge, shows the new-message overlay with the phone number prefilled. |
-| `textbridge://search?q=dinner` | Opens Textbridge, focuses the search bar, types the query. |
-| `textbridge://conversation/<conversation-id>` | Opens Textbridge and reveals a specific thread. |
-| `textbridge://open` | Just brings Textbridge to the front. Useful as a global hotkey target. |
+| `txt://compose?to=+61412345678&body=hello` | If both `to` **and** `body` are present, sends the message in the background (no window focus, no overlay). If `body` is missing, opens txt with the new-message overlay and the handle prefilled. |
+| `txt://compose?to=+61412345678` | Opens txt, shows the new-message overlay with the recipient prefilled. User types + sends. |
+| `txt://search?q=dinner` | Opens txt, focuses the search bar, types the query. |
+| `txt://conversation/<conversation-id>` | Opens txt and reveals a specific thread. |
+| `txt://open` | Just brings txt to the front. Useful as a global hotkey target. |
 
-`body` on `compose` is accepted but not yet wired through to the composer
-input — the overlay currently only prefills the phone. The scheme reserves
-the key for a later pass.
+### Handle routing
+
+`to` is a phone number or an email address.
+
+- **Phone number** (`+61412345678`, `0412 345 678`, etc.) → routed to
+  Google Messages. The Rust shell calls `POST /api/new-conversation` on
+  the Go backend, which is the same get-or-create path the in-app New
+  Message overlay uses.
+- **Email address** (`someone@example.com`) → routed to iMessage. The
+  conversation ID is `imessage:<handle>`; the Go backend's iMessage
+  sender picks it up directly via `osascript`.
+
+Other handle shapes are rejected at the Rust layer and logged to the app
+console (`[deep-link] …`). Open an issue if you need another route.
+
+### Auto-send vs. overlay
+
+The `compose` action has two modes depending on the query string:
+
+| Query shape | Behaviour | Focus-stealing? |
+|-------------|-----------|----|
+| `?to=X&body=Y` (both set) | Resolve handle → POST `/api/send` in the background | No — app stays in the background. |
+| `?to=X` (body missing/empty) | Open the new-message overlay with `to` prefilled, focus the window | Yes — user wanted to review. |
+| `?body=Y` (to missing) | Open the overlay with `body` prefilled, focus the window | Yes. |
+
+If the auto-send path fails (e.g. backend not running, recipient can't
+be resolved), it falls through to the overlay so the user gets a visible
+retry affordance.
 
 ## Recipes
 
-### Send a text message to a contact
+### Send a text message to a contact (auto-send)
 
 1. Open Shortcuts.app → **File → New Shortcut**.
 2. Drop in these actions in order:
    - **Ask for Input** (prompt: "Phone number", type: Text)
-   - **URL** → `textbridge://compose?to=[Provided Input]`
+   - **Ask for Input** (prompt: "Message", type: Text)
+   - **URL** → `txt://compose?to=[Provided Input 1]&body=[URL-Encoded Input 2]`
    - **Open URLs**
-3. Name it "Text via Textbridge". It now appears in Spotlight, the menu bar,
-   and can be triggered from Siri ("Text via Textbridge").
+3. Name it "Send a Message With txt". It now appears in Spotlight, the
+   menu bar, and can be triggered from Siri ("Send a Message With txt").
+
+This recipe corresponds 1:1 to the `Send a Message With txt` App Intent
+mentioned in the codebase roadmap — we achieve the intent's behaviour
+through the URL scheme handler instead of shipping a Swift App Intents
+target.
+
+### Open the composer with a contact prefilled (no auto-send)
+
+1. New Shortcut.
+2. Actions:
+   - **Ask for Input** (prompt: "Phone number", type: Text)
+   - **URL** → `txt://compose?to=[Provided Input]`
+   - **Open URLs**
+3. Name it "Text via txt".
 
 ### Search all messages for a term
 
 1. New Shortcut.
 2. Actions:
-   - **Ask for Input** (prompt: "Search Textbridge for…", type: Text)
+   - **Ask for Input** (prompt: "Search txt for…", type: Text)
    - **URL Encode**
-   - **Text** → `textbridge://search?q=[URL-Encoded Text]`
+   - **Text** → `txt://search?q=[URL-Encoded Text]`
    - **Open URLs**
-3. Name it "Search Textbridge".
+3. Name it "Search txt".
 
 ### Jump to a pinned conversation
 
 1. Find the conversation ID — either via the MCP `list_conversations` tool
-   or by opening the conversation in Textbridge and copying the
+   or by opening the conversation in txt and copying the
    `?conversation=…` value from the in-app URL bar (⌘L).
-2. New Shortcut → **URL** → `textbridge://conversation/<paste-id-here>`
+2. New Shortcut → **URL** → `txt://conversation/<paste-id-here>`
    → **Open URLs**.
 3. Bind to a hotkey in **System Settings → Keyboard → Keyboard Shortcuts
    → Services** for a one-key jump.
@@ -54,25 +100,67 @@ the key for a later pass.
 ## Testing from the shell
 
 ```bash
+# Auto-send (Google Messages, phone)
+open 'txt://compose?to=+61412345678&body=smoke%20test'
+
+# Auto-send (iMessage, email)
+open 'txt://compose?to=someone@example.com&body=smoke%20test'
+
+# Open overlay only (no body)
+open 'txt://compose?to=+61412345678'
+
+# Search
+open 'txt://search?q=groceries'
+
+# Specific conversation
+open 'txt://conversation/imessage:+61412345678'
+
+# Just focus the window
+open 'txt://open'
+
+# Legacy scheme still works
 open 'textbridge://compose?to=+61412345678'
-open 'textbridge://search?q=groceries'
-open 'textbridge://conversation/conv-abc123'
-open 'textbridge://open'
+```
+
+There's an end-to-end smoke test at
+`desktop/scripts/smoke-url-scheme` that fires an `open txt://compose?…`
+and asserts a message landed in the outgoing queue. Run it manually
+after launching the app:
+
+```bash
+./desktop/scripts/dev --launch
+./desktop/scripts/smoke-url-scheme +61412345678 "smoke from $(date +%s)"
 ```
 
 Each `open` hands the URL off to `LaunchServices`, which resolves
 `CFBundleURLTypes` (registered via `plugins.deep-link.desktop.schemes` in
-`desktop/src-tauri/tauri.conf.json`) and fires the Tauri deep-link event
-the Rust shell listens on.
+`desktop/src-tauri/tauri.conf.json`) and dispatches into
+`dispatch_deep_link` in the Rust shell. `compose` with both `to` and
+`body` runs the send path directly; everything else is emitted as a
+Tauri event the WebView listens to.
 
-## Why URL-scheme instead of App Intents
+## Design rationale: URL scheme vs. App Intents
 
-Tauri 2 macOS apps don't have a first-class Swift target; embedding an
-App Intents bundle requires either a separate Xcode project or a
-substantial `build.rs` Swift-toolchain integration. The URL scheme covers
-the same user-facing ground — Shortcuts.app's **Open URLs** is equivalent
-in power to a shallow `@AppIntent`, and third-party automation (Raycast,
-Alfred, keyboard-driven launchers) pick it up for free.
+Tauri 2 macOS apps don't have a first-class Swift target. Shipping a
+proper App Intents bundle (`@AppIntent` + `AppShortcutsProvider`)
+requires one of:
 
-Moving to a proper App Intents bundle is tracked as a follow-up once the
-build-system surgery is worth the lift.
+1. A separate Xcode project producing a `.appex` that we embed under
+   `Contents/PlugIns/` and sign alongside the Tauri bundle.
+2. A substantial `build.rs` integration that drives `xcrun swiftc` +
+   `actool` from Cargo and stitches the resulting binary into the bundle.
+
+Both are doable but non-trivial, and there's no user-facing win for the
+extra surface: Shortcuts.app's **Open URLs** action is equivalent in
+power to a shallow `@AppIntent`. A one-action shortcut named "Send a
+Message With txt" is indistinguishable from a proper App Intent as far
+as the Shortcuts library, Siri, and Spotlight are concerned. Third-party
+launchers (Raycast, Alfred) also pick the URL scheme up for free.
+
+The trade-off we accept: Shortcut parameters are typed as `Text` and
+filled via `Ask for Input` actions rather than surfaced as native
+parameter editors in the Shortcuts parameter list. The Shortcuts UX is
+marginally less polished. If that becomes a real gripe we'll lift the
+existing `compose` URL into a Swift App Intents bundle, keep the URL
+scheme as the transport, and get the native UI for free — the backend
+plumbing won't change.


### PR DESCRIPTION
Roadmap P1 #11 + partial #8. tauri-plugin-deep-link handles both txt:// (primary) and textbridge:// (legacy). txt://compose?to=<handle>&body=<text> focuses the window and either auto-sends (background, when body present) or pre-fills the composer (interactive). ⌥⇧T global hotkey focuses the compose field. Smoke script at desktop/scripts/smoke-url-scheme. Shortcuts.app App Intents not shipped (rate-limit); URL scheme IS Shortcut-triggerable via 'Open URLs' — see docs/shortcuts.md.