### PR TITLE
release: v0.8.8

### DIFF
--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "txt",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "identifier": "ai.james-is-an.textbridge",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Automated version bump cut by `desktop/scripts/release`.