### PR TITLE
fix(scripts): dev APP_NAME matches renamed productName

### DIFF
--- a/.agent-context
+++ b/.agent-context
@@ -2,8 +2,8 @@
 # Max 20 lines. Updated by agent on Stop hook.
 
 ## Feature
-Menu-bar popover
-NSStatusItem tray with VIP list + unread badge + quick compose (issue #20 item 1, #15 item #5b)
+Fix scripts/dev APP_NAME
+Change stale "Textbridge" to "txt" so scripts/dev --launch finds the built bundle
 
 ## Current State
 Not started. No work has been done yet.

--- a/.agent-progress
+++ b/.agent-progress
@@ -1,10 +1,10 @@
-# Agent Progress - menu-bar-popover
+# Agent Progress - fix-dev-script-name
 # Format: KEY=VALUE, one per line. Agents append, last value wins.
-# Created: 2026-04-19T11:21:50Z
+# Created: 2026-04-19T11:55:31Z
 
-feature=menu-bar-popover
-name=Menu-bar popover
+feature=fix-dev-script-name
+name=Fix scripts/dev APP_NAME
 status=pending
 step=0
 step_name=Not started
-created=2026-04-19T11:21:50Z
+created=2026-04-19T11:55:31Z

--- a/desktop/scripts/dev
+++ b/desktop/scripts/dev
@@ -8,7 +8,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(dirname "$SCRIPT_DIR")"
-APP_NAME="Textbridge"
+APP_NAME="txt"
 DEV_APP_NAME="${APP_NAME}-dev"
 RELEASE_DIR="$REPO_DIR/release/dev"
 DEV_APP="$RELEASE_DIR/${DEV_APP_NAME}.app"


### PR DESCRIPTION
One-line fix: `scripts/dev` hardcoded `APP_NAME="Textbridge"` from before the product rename. cargo tauri build produces `txt-dev.app` (productName `txt` + `-dev` suffix), but the script expected `Textbridge-dev.app` and errored out after a 2-min compile. `scripts/release` already uses `APP_NAME="txt"`; aligning.